### PR TITLE
taking elasticsearch namespace into consideration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= v0.4.0
+VERSION ?= v0.4.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/elasticgo/client.go
+++ b/elasticgo/client.go
@@ -53,7 +53,7 @@ func generateElasticClient(cr *loggingv1beta1.Elasticsearch) (esapi.Transport, e
 	} else {
 		urlScheme = "http"
 	}
-	elasticURL := fmt.Sprintf("%s://%s-master:9200", urlScheme, cr.ObjectMeta.Name)
+	elasticURL := fmt.Sprintf("%s://%s-master.%s:9200", urlScheme, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace)
 	cfg := elasticsearch.Config{
 		Addresses: []string{
 			elasticURL,


### PR DESCRIPTION
Fix for scenarios where the operator is running in one namespace but the elasticsearch cr is in another. The `{instance}-sa-token` secret won't be created and grafana will not be able to connect.